### PR TITLE
Add Dialyxir and typespecs

### DIFF
--- a/lib/base64.ex
+++ b/lib/base64.ex
@@ -10,6 +10,7 @@ defmodule Base64 do
   @doc """
   Encode binary file using base64
   """
+  @spec encode_file(binary(), binary()) :: :ok | {:error, term()}
   def encode_file(input_path, output_path) do
     input_path
     |> read_file()
@@ -32,17 +33,20 @@ defmodule Base64 do
       "TWFu"
 
   """
+  @spec encode(binary()) :: binary()
   def encode(data) do
     {data, n_padding} = ensure_size(data)
     do_encode(data, n_padding)
   end
 
+  @spec do_encode(binary(), non_neg_integer()) :: binary()
   defp do_encode(data, n_padding) do
     data
     |> chunk_by(6)
     |> convert_to_ascii(n_padding)
   end
 
+  @spec convert_to_ascii([<<_::6>>], non_neg_integer()) :: binary()
   defp convert_to_ascii(sixtets, n_padding) do
     result = sixtets
       |> Enum.map(&table_lookup/1)
@@ -51,12 +55,15 @@ defmodule Base64 do
     result <> String.duplicate(@pad, n_padding)
   end
 
+  @spec table_lookup(<<_::6>>) :: binary() | nil
   defp table_lookup(<<sixtet_value::6>>), do: String.at(@base64_table, sixtet_value)
 
+  @spec chunk_by(bitstring(), 6) :: [<<_::6>>]
   defp chunk_by(data, n_chunk) do
     for << c::size(n_chunk) <- data >>, do: <<c::size(n_chunk)>>
   end
 
+  @spec ensure_size(bitstring()) :: {bitstring(), integer()}
   defp ensure_size(data) do
     n_padding = rem(bit_size(data), @source_chunk_size)
     x = 6 - n_padding
@@ -68,6 +75,7 @@ defmodule Base64 do
     end
   end
 
+  @spec write_file(binary(), binary()) :: :ok | {:error, atom()}
   defp write_file(data, path) do
     with {:ok, file_handle} <- File.open(path, [:write]) do
       file_handle
@@ -75,6 +83,7 @@ defmodule Base64 do
     end
   end
 
+  @spec read_file(binary()) :: :eof | binary() | [byte()] | {:error, atom() | {:no_translation, :unicode, :latin1}}
   defp read_file(path) do
     with {:ok, file_handle} <- File.open(path) do
       file_handle

--- a/mix.exs
+++ b/mix.exs
@@ -21,8 +21,7 @@ defmodule Base64.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,3 @@
+%{
+  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.3", "774306f84973fc3f1e2e8743eeaa5f5d29b117f3916e5de74c075c02f1b8ef55", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
This PR addresses issue https://github.com/denvaar/base64/issues/3 by adding typespecs for all the functions, and adds Dialyxir as a dependency to check them with.

I opted to use the 1.0 RC3 of Dialyxir rather than latest "stable" version 0.5, as RC3 is already stable and comes with many improvements over the older 0.5.