### PR TITLE
Create executable program

### DIFF
--- a/lib/base64.ex
+++ b/lib/base64.ex
@@ -7,6 +7,16 @@ defmodule Base64 do
   @pad "="
   @source_chunk_size 3
 
+  @doc """
+  Decode ASCII file using base64
+  """
+  @spec decode_file(binary(), binary()) :: :ok | {:error, term()}
+  def decode_file(input_path, output_path) do
+    input_path
+    |> read_file()
+    |> decode()
+    |> write_file(output_path)
+  end
 
   @doc """
   Decode ASCII text back to binary data
@@ -132,4 +142,34 @@ defmodule Base64 do
       |> IO.binread(:all)
     end
   end
+end
+
+defmodule Base64.CLI do
+  def main(args \\ []) do
+    args
+    |> parse_args
+    |> response
+  end
+
+  defp parse_args(args) do
+    {opts, word, _} =
+      args
+      |> OptionParser.parse(switches: [encode: :boolean, decode: :boolean])
+    {opts, word}
+  end
+
+  defp usage() do
+    IO.puts("""
+Usage: ./base64 [--encode|--decode] [infile] [outfile]\
+""")
+  end
+
+  defp response({opts, word}) do
+    case {opts, word} do
+      {[encode: true], [i, o]} -> Base64.encode_file(i, o)
+      {[decode: true], [i, o]} -> Base64.decode_file(i, o)
+      _ -> usage()
+    end
+  end
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,8 @@ defmodule Base64.MixProject do
       version: "0.1.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      escript: escript(),
     ]
   end
 
@@ -22,6 +23,12 @@ defmodule Base64.MixProject do
   defp deps do
     [
       {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false}
+    ]
+  end
+
+  defp escript do
+    [
+      main_module: Base64.CLI
     ]
   end
 end


### PR DESCRIPTION
Resolves #2.

Executable is built with `mix escript.build`. A few issues remain:

- The script has no access to argv[0] which can help show a better `usage()` message.
- Ideally, when no files are present, the script should stream from stdin to stdout, but I couldn't find a good way to read stdin without changing `Base64` too much.